### PR TITLE
Add permission for config

### DIFF
--- a/octobox/config.json
+++ b/octobox/config.json
@@ -20,6 +20,7 @@
     "3333/tcp": 3333
   },
   "map": [
+    "config",
     "ssl"
   ],
   "options": {


### PR DESCRIPTION
# Proposed Changes
Add permission for config folder, otherwise secrets can't be used.
Base image supports them, according to the docs it's possible, but the config.json doesn't allow it.